### PR TITLE
security: bump MessagePack 2.1.90 -> 2.5.187 (CVE-2024-48924)

### DIFF
--- a/Server/Server.csproj
+++ b/Server/Server.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.1.90" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/dev/dev.csproj
+++ b/dev/dev.csproj
@@ -7,14 +7,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.1.90" />
+    <PackageReference Include="MessagePack" Version="2.5.187" />
     <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>


### PR DESCRIPTION
Addresses CVE-2024-48924 (MessagePack moderate severity).

- `Server/Server.csproj`: 2.1.90 → 2.5.187
- `dev/dev.csproj`: 2.1.90 → 2.5.187. Also retargets from EOL `netcoreapp2.2` to `net8.0` (transitive deps no longer support netcoreapp2.2) and drops `OutputType=Exe` because the project's `Main()` has been commented out for some time, so it could not have been executed as an exe anyway.

Verified: `dotnet build` succeeds for Server and dev.